### PR TITLE
ignore case sensitivity in sourcefile mapping(#12)

### DIFF
--- a/src/debug/netcoredbg/SymbolReader.cs
+++ b/src/debug/netcoredbg/SymbolReader.cs
@@ -254,9 +254,9 @@ namespace SOS
                 Func<string, bool> FileNameMatches;
                 string fileName = GetFileName(filePath);
                 if (fileName == filePath)
-                    FileNameMatches = s => GetFileName(s) == fileName;
+                    FileNameMatches = s => GetFileName(s).Equals(fileName, StringComparison.OrdinalIgnoreCase);
                 else
-                    FileNameMatches = s => s == filePath;
+                    FileNameMatches = s => s.Equals(filePath, StringComparison.OrdinalIgnoreCase);
 
                 foreach (MethodDebugInformationHandle methodDebugInformationHandle in reader.MethodDebugInformation)
                 {


### PR DESCRIPTION
in filename-insensitive filesystem like windows NTFS, sometimes netcoredbg misses source file even if local build machine.