### PR TITLE
Converted to 32 bit frame id (attempt 2).

### DIFF
--- a/src/debug/netcoredbg/breakpoints.cpp
+++ b/src/debug/netcoredbg/breakpoints.cpp
@@ -93,7 +93,7 @@ HRESULT Breakpoints::HandleEnabled(BreakpointType &bp, Debugger *debugger, ICorD
     {
         DWORD threadId = 0;
         IfFailRet(pThread->GetID(&threadId));
-        uint64_t frameId = StackFrame(threadId, 0, "").id;
+        uint32_t frameId = StackFrame(threadId, 0, "").id;
 
         Variable variable;
         std::string output;

--- a/src/debug/netcoredbg/debugger.h
+++ b/src/debug/netcoredbg/debugger.h
@@ -54,12 +54,12 @@ public:
     virtual void InsertExceptionBreakpoint(const std::string &name, Breakpoint &breakpoint) = 0;
     virtual HRESULT GetStackTrace(int threadId, int startFrame, int levels, std::vector<StackFrame> &stackFrames, int &totalFrames) = 0;
     virtual HRESULT StepCommand(int threadId, StepType stepType) = 0;
-    virtual HRESULT GetScopes(uint64_t frameId, std::vector<Scope> &scopes) = 0;
+    virtual HRESULT GetScopes(uint32_t frameId, std::vector<Scope> &scopes) = 0;
     virtual HRESULT GetVariables(uint32_t variablesReference, VariablesFilter filter, int start, int count, std::vector<Variable> &variables) = 0;
     virtual int GetNamedVariables(uint32_t variablesReference) = 0;
-    virtual HRESULT Evaluate(uint64_t frameId, const std::string &expression, Variable &variable, std::string &output) = 0;
+    virtual HRESULT Evaluate(uint32_t frameId, const std::string &expression, Variable &variable, std::string &output) = 0;
     virtual HRESULT SetVariable(const std::string &name, const std::string &value, uint32_t ref, std::string &output) = 0;
-    virtual HRESULT SetVariableByExpression(uint64_t frameId, const std::string &name, const std::string &value, std::string &output) = 0;
+    virtual HRESULT SetVariableByExpression(uint32_t frameId, const std::string &name, const std::string &value, std::string &output) = 0;
 };
 
 class Protocol

--- a/src/debug/netcoredbg/main.cpp
+++ b/src/debug/netcoredbg/main.cpp
@@ -17,6 +17,7 @@ static const uint16_t DEFAULT_SERVER_PORT = 4711;
 
 std::unordered_map<uint64_t, uint32_t> StackFrameData::idStore {};
 uint32_t StackFrameData::nextId = 0;
+std::unordered_map<uint32_t, uint64_t> StackFrame::keyStore {};
 
 static void print_help()
 {

--- a/src/debug/netcoredbg/main.cpp
+++ b/src/debug/netcoredbg/main.cpp
@@ -15,6 +15,9 @@
 
 static const uint16_t DEFAULT_SERVER_PORT = 4711;
 
+std::unordered_map<uint64_t, uint32_t> StackFrameData::idStore {};
+uint32_t StackFrameData::nextId = 0;
+
 static void print_help()
 {
     fprintf(stdout,

--- a/src/debug/netcoredbg/manageddebugger.h
+++ b/src/debug/netcoredbg/manageddebugger.h
@@ -318,9 +318,9 @@ class Variables
 
         ValueKind valueKind;
         ToRelease<ICorDebugValue> value;
-        uint64_t frameId;
+        uint32_t frameId;
 
-        VariableReference(const Variable &variable, uint64_t frameId, ToRelease<ICorDebugValue> value, ValueKind valueKind) :
+        VariableReference(const Variable &variable, uint32_t frameId, ToRelease<ICorDebugValue> value, ValueKind valueKind) :
             variablesReference(variable.variablesReference),
             namedVariables(variable.namedVariables),
             indexedVariables(variable.indexedVariables),
@@ -330,7 +330,7 @@ class Variables
             frameId(frameId)
         {}
 
-        VariableReference(uint32_t variablesReference, uint64_t frameId, int namedVariables) :
+        VariableReference(uint32_t variablesReference, uint32_t frameId, int namedVariables) :
             variablesReference(variablesReference),
             namedVariables(namedVariables),
             indexedVariables(0),
@@ -350,10 +350,10 @@ class Variables
     std::unordered_map<uint32_t, VariableReference> m_variables;
     uint32_t m_nextVariableReference;
 
-    void AddVariableReference(Variable &variable, uint64_t frameId, ICorDebugValue *value, ValueKind valueKind);
+    void AddVariableReference(Variable &variable, uint32_t frameId, ICorDebugValue *value, ValueKind valueKind);
 
     HRESULT GetStackVariables(
-        uint64_t frameId,
+        uint32_t frameId,
         ICorDebugThread *pThread,
         ICorDebugFrame *pFrame,
         int start,
@@ -388,7 +388,7 @@ class Variables
         bool static_members = false);
 
     HRESULT SetStackVariable(
-        uint64_t frameId,
+        uint32_t frameId,
         ICorDebugThread *pThread,
         ICorDebugFrame *pFrame,
         const std::string &name,
@@ -431,16 +431,16 @@ public:
         ICorDebugProcess *pProcess,
         ICorDebugValue *pVariable,
         const std::string &value,
-        uint64_t frameId,
+        uint32_t frameId,
         std::string &output);
 
-    HRESULT GetScopes(ICorDebugProcess *pProcess, uint64_t frameId, std::vector<Scope> &scopes);
+    HRESULT GetScopes(ICorDebugProcess *pProcess, uint32_t frameId, std::vector<Scope> &scopes);
 
-    HRESULT Evaluate(ICorDebugProcess *pProcess, uint64_t frameId, const std::string &expression, Variable &variable, std::string &output);
+    HRESULT Evaluate(ICorDebugProcess *pProcess, uint32_t frameId, const std::string &expression, Variable &variable, std::string &output);
 
     HRESULT GetValueByExpression(
         ICorDebugProcess *pProcess,
-        uint64_t frameId,
+        uint32_t frameId,
         const std::string &expression,
         ICorDebugValue **ppResult);
 
@@ -549,10 +549,10 @@ public:
     void InsertExceptionBreakpoint(const std::string &name, Breakpoint &breakpoint) override;
     HRESULT GetStackTrace(int threadId, int startFrame, int levels, std::vector<StackFrame> &stackFrames, int &totalFrames) override;
     HRESULT StepCommand(int threadId, StepType stepType) override;
-    HRESULT GetScopes(uint64_t frameId, std::vector<Scope> &scopes) override;
+    HRESULT GetScopes(uint32_t frameId, std::vector<Scope> &scopes) override;
     HRESULT GetVariables(uint32_t variablesReference, VariablesFilter filter, int start, int count, std::vector<Variable> &variables) override;
     int GetNamedVariables(uint32_t variablesReference) override;
-    HRESULT Evaluate(uint64_t frameId, const std::string &expression, Variable &variable, std::string &output) override;
+    HRESULT Evaluate(uint32_t frameId, const std::string &expression, Variable &variable, std::string &output) override;
     HRESULT SetVariable(const std::string &name, const std::string &value, uint32_t ref, std::string &output) override;
-    HRESULT SetVariableByExpression(uint64_t frameId, const std::string &expression, const std::string &value, std::string &output) override;
+    HRESULT SetVariableByExpression(uint32_t frameId, const std::string &expression, const std::string &value, std::string &output) override;
 };

--- a/src/debug/netcoredbg/miprotocol.cpp
+++ b/src/debug/netcoredbg/miprotocol.cpp
@@ -432,7 +432,7 @@ HRESULT MIProtocol::CreateVar(int threadId, int level, const std::string &varobj
 {
     HRESULT Status;
 
-    uint64_t frameId = StackFrame(threadId, level, "").id;
+    uint32_t frameId = StackFrame(threadId, level, "").id;
 
     Variable variable;
     IfFailRet(m_debugger->Evaluate(frameId, expression, variable, output));
@@ -1129,7 +1129,7 @@ HRESULT MIProtocol::HandleCommand(std::string command,
 
         int threadId = GetIntArg(args, "--thread", m_debugger->GetLastStoppedThreadId());
         int level = GetIntArg(args, "--frame", 0);
-        uint64_t frameId = StackFrame(threadId, level, "").id;
+        uint32_t frameId = StackFrame(threadId, level, "").id;
 
         Variable variable;
         IfFailRet(FindVar(varName, variable));

--- a/src/debug/netcoredbg/variables.cpp
+++ b/src/debug/netcoredbg/variables.cpp
@@ -205,7 +205,7 @@ HRESULT Variables::GetVariables(
     return S_OK;
 }
 
-void Variables::AddVariableReference(Variable &variable, uint64_t frameId, ICorDebugValue *value, ValueKind valueKind)
+void Variables::AddVariableReference(Variable &variable, uint32_t frameId, ICorDebugValue *value, ValueKind valueKind)
 {
     unsigned int numChild = 0;
     GetNumChild(value, numChild, valueKind == ValueIsClass);
@@ -220,7 +220,7 @@ void Variables::AddVariableReference(Variable &variable, uint64_t frameId, ICorD
 }
 
 HRESULT Variables::GetStackVariables(
-    uint64_t frameId,
+    uint32_t frameId,
     ICorDebugThread *pThread,
     ICorDebugFrame *pFrame,
     int start,
@@ -271,14 +271,14 @@ HRESULT Variables::GetStackVariables(
     return S_OK;
 }
 
-HRESULT ManagedDebugger::GetScopes(uint64_t frameId, std::vector<Scope> &scopes)
+HRESULT ManagedDebugger::GetScopes(uint32_t frameId, std::vector<Scope> &scopes)
 {
     LogFuncEntry();
 
     return m_variables.GetScopes(m_pProcess, frameId, scopes);
 }
 
-HRESULT Variables::GetScopes(ICorDebugProcess *pProcess, uint64_t frameId, std::vector<Scope> &scopes)
+HRESULT Variables::GetScopes(ICorDebugProcess *pProcess, uint32_t frameId, std::vector<Scope> &scopes)
 {
     if (pProcess == nullptr)
         return E_FAIL;
@@ -406,7 +406,7 @@ HRESULT Variables::GetChildren(
     return S_OK;
 }
 
-HRESULT ManagedDebugger::Evaluate(uint64_t frameId, const std::string &expression, Variable &variable, std::string &output)
+HRESULT ManagedDebugger::Evaluate(uint32_t frameId, const std::string &expression, Variable &variable, std::string &output)
 {
     LogFuncEntry();
 
@@ -415,7 +415,7 @@ HRESULT ManagedDebugger::Evaluate(uint64_t frameId, const std::string &expressio
 
 HRESULT Variables::Evaluate(
     ICorDebugProcess *pProcess,
-    uint64_t frameId,
+    uint32_t frameId,
     const std::string &expression,
     Variable &variable,
     std::string &output)
@@ -587,7 +587,7 @@ HRESULT Variables::SetVariable(
 }
 
 HRESULT Variables::SetStackVariable(
-    uint64_t frameId,
+    uint32_t frameId,
     ICorDebugThread *pThread,
     ICorDebugFrame *pFrame,
     const std::string &name,
@@ -657,7 +657,7 @@ HRESULT Variables::SetChild(
 }
 
 HRESULT ManagedDebugger::SetVariableByExpression(
-    uint64_t frameId,
+    uint32_t frameId,
     const std::string &expression,
     const std::string &value,
     std::string &output)
@@ -669,7 +669,7 @@ HRESULT ManagedDebugger::SetVariableByExpression(
     return m_variables.SetVariable(m_pProcess, pResultValue, value, frameId, output);
 }
 
-HRESULT Variables::GetValueByExpression(ICorDebugProcess *pProcess, uint64_t frameId, const std::string &expression,
+HRESULT Variables::GetValueByExpression(ICorDebugProcess *pProcess, uint32_t frameId, const std::string &expression,
                                         ICorDebugValue **ppResult)
 {
     if (pProcess == nullptr)
@@ -690,7 +690,7 @@ HRESULT Variables::SetVariable(
     ICorDebugProcess *pProcess,
     ICorDebugValue *pVariable,
     const std::string &value,
-    uint64_t frameId,
+    uint32_t frameId,
     std::string &output)
 {
     HRESULT Status;

--- a/src/debug/netcoredbg/vscodeprotocol.cpp
+++ b/src/debug/netcoredbg/vscodeprotocol.cpp
@@ -413,7 +413,7 @@ HRESULT VSCodeProtocol::HandleCommand(const std::string &command, const json &ar
     { "evaluate", [this](const json &arguments, json &body){
         HRESULT Status;
         std::string expression = arguments.at("expression");
-        uint64_t frameId;
+        uint32_t frameId;
         auto frameIdIter = arguments.find("frameId");
         if (frameIdIter == arguments.end())
         {


### PR DESCRIPTION
#22 uses some hack and it does not work when thread id is in fact 32 bit.

In this pull request, I took another approach, to use a map instead.

It still looks ugly, but can enable me to test the MonoDevelop extension more reliably.

Note that this should not be merged, as I didn't even take care of the unit test cases. It is sent merely to indicate the possibility to switch to 32 bit.