### PR TITLE
Removed header #include <sys/wait.h>

### DIFF
--- a/src/debug/netcoredbg/manageddebugger.cpp
+++ b/src/debug/netcoredbg/manageddebugger.cpp
@@ -31,7 +31,6 @@ using std::map;
 #include <pthread.h>
 #include <link.h>
 #include <sys/types.h>
-#include <sys/wait.h>
 
 namespace {
 namespace hook {


### PR DESCRIPTION
#43 Following the tip of @viewizard I removed this header in order to build the application in Manjaro(ArchLinux)