### PR TITLE
Handle invalid frameId when evaluating expression

### DIFF
--- a/src/debug/netcoredbg/manageddebugger.h
+++ b/src/debug/netcoredbg/manageddebugger.h
@@ -531,6 +531,7 @@ public:
 
     HRESULT Evaluate(ICorDebugProcess *pProcess,
         uint64_t frameId,
+        int threadId,
         const std::string &expression,
         Variable &variable,
         std::string &output);


### PR DESCRIPTION
Previously, this would cause a segfault. After this change, there is the same behavior as not passing a frameId.