### PR TITLE
Added action and Dockerfile for arm64

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -1,0 +1,30 @@
+name: netcoredbg Release CI
+
+on:
+  release:
+    types:
+      - created
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and export
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: netcoredbg:latest
+          outputs: type=local,dest=/tmp
+      - name: Upload release build
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: /tmp/netcoredbg-linux-arm64.tar.gz
+          asset_name: netcoredbg-linux-arm64.tar.gz
+          asset_content_type: application/zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04 AS builder-stage
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Copy contents to opt
+COPY . /opt/netcoredbg
+
+# Installing packages
+RUN apt update && apt install -y curl git cmake clang g++-aarch64-linux-gnu && \
+    rm -rf /var/lib/apt/lists/*
+
+# set libraries and fix path for aarch64
+ENV CPLUS_INCLUDE_PATH=/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu
+RUN cd /usr/include && ln -s ../aarch64-linux-gnu/include aarch64-linux-gnu
+
+# download everything and compile
+RUN cd /usr/local/bin && curl -fsSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh && chmod 755 /usr/local/bin/dotnet-install.sh && dotnet-install.sh --channel 3.1 --install-dir /opt/dotnet && dotnet-install.sh --architecture arm64 --channel 3.1 --install-dir /opt/dotnet-aarch64
+RUN cd /opt && git clone -b release/3.1 https://github.com/dotnet/coreclr.git
+RUN DBGSHIM_LOCATION=`find /opt/dotnet-aarch64/shared/Microsoft.NETCore.App \( -name dbgshim.dll -o -name libdbgshim.so -o -name libdbgshim.dylib \) | head -n 1` && \
+    mkdir -p /opt/netcoredbg/build && cd /opt/netcoredbg/build && \
+    CC=clang CXX=clang++ cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/../bin/netcoredbg -DCORECLR_DIR=/opt/coreclr -DDOTNET_DIR=/opt/dotnet -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DDBGSHIM_LOCATION=${DBGSHIM_LOCATION} && make && make install && \ 
+    cd /opt/netcoredbg/bin && tar -zcvf netcoredbg-linux-arm64.tar.gz netcoredbg
+
+FROM scratch
+COPY --from=builder-stage /opt/netcoredbg/bin/netcoredbg-linux-arm64.tar.gz /


### PR DESCRIPTION
This Dockerfile is an answer to #36 and cross-compiles for arm64 on a x86-server. With the github-action I can directly create an arm64-package when a new release is tagged.
I've tested it successfully on my rpi4 with 64bit Raspberry OS.

Why only a draft PR?
- I don't know your current build chain, at least I didn't see any github-action. Maybe there are better ways to integrate this
- Maybe we should rename the Dockerfile to something like Dockerfile-aarch64 (or similar) or add arguments (for usage with other architectures), for now only arm64 is possible (so will work on rpi4 64bit, but not 32bit)

Open to suggestions!
Thanks