### PR TITLE
Adding limits due to GCC11 changes

### DIFF
--- a/src/debugger/frames.cpp
+++ b/src/debugger/frames.cpp
@@ -4,6 +4,7 @@
 
 #include <sstream>
 #include <algorithm>
+#include <limits>
 #include "debugger/frames.h"
 #include "metadata/typeprinter.h"
 #include "utils/platform.h"


### PR DESCRIPTION
Could not build with GCC11, found issue and added limit header

https://www.gnu.org/software/gcc/gcc-11/porting_to.html#header-dep-changes