### PR TITLE
docs: fix GDB/MI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Debugger for .NET Core runtime
 
-The debugger provides [GDB/MI](https://sourceware.org/gdb/current/onlinedocs/gdb/GDB_002fMI.html)
-and [VSCode Debug Adapterprotocol](https://microsoft.github.io/debug-adapter-protocol/)
+The debugger provides [GDB/MI](https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI.html)
+and [VSCode Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/)
 and allows to debug .NET apps under .NET Core runtime.  Also debugger allows debugging from
 command line (like as GDB).
 

--- a/packaging/netcoredbg.spec
+++ b/packaging/netcoredbg.spec
@@ -1,6 +1,6 @@
 Name:      netcoredbg
 Summary:   Managed code debugger for CoreCLR
-Version:   2.2.2
+Version:   2.2.3
 Release:   1
 Group:     Development/Toolchain
 License:   MIT

--- a/src/version.h
+++ b/src/version.h
@@ -3,4 +3,4 @@
 // See the LICENSE file in the project root for more information.
 
 // WARNING: do not modify this file! Generated automatically.
-static const char __VERSION[] = "2.2.2-1";
+static const char __VERSION[] = "2.2.3-1";


### PR DESCRIPTION
Current GDB/MI link gives an HTTP 404 error.

Also, this fixes a small typo.
