### PR TITLE
src/interfaces/types.h: add missing cstdint include

### DIFF
--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <cassert>
 #include <climits>
+#include <cstdint>
 
 namespace netcoredbg
 {


### PR DESCRIPTION
w/o this it fails to compile with Clang-16 OR GCC-13