### PR TITLE
Added symbols loading when loading in-memory modules

### DIFF
--- a/src/managed/interop.cpp
+++ b/src/managed/interop.cpp
@@ -111,9 +111,11 @@ constexpr char UtilsClassName[] = "NetCoreDbg.Utils";
 // Returns the number of bytes read.
 int ReadMemoryForSymbols(uint64_t address, char *buffer, int cb)
 {
-    // TODO: In-memory PDB?
-    // OSPageSize() for Linux/Windows already implemented in code.
-    return 0;
+    if (address == 0 || buffer == 0 || cb == 0)
+        return 0;
+
+    std::memcpy(buffer, (const void*) address, cb);
+    return cb;
 }
 
 } // unnamed namespace

--- a/src/metadata/modules.cpp
+++ b/src/metadata/modules.cpp
@@ -486,20 +486,17 @@ static HRESULT LoadSymbols(IMetaDataImport *pMD, ICorDebugModule *pModule, VOID 
 
     std::vector<unsigned char> peBuf;
     ULONG64 peBufAddress = 0;
-    if (isInMemory)
+    if (isInMemory && peAddress != 0 && peSize != 0)
     {
         ToRelease<ICorDebugProcess> process;
         IfFailRet(pModule->GetProcess(&process));
 
-        if (peAddress != 0 && peSize != 0)
-        {
-            peBuf.resize(peSize);
-            peBufAddress = (ULONG64)&peBuf[0];
-            SIZE_T read = 0;
-            IfFailRet(process->ReadMemory(peAddress, peSize, &peBuf[0], &read));
-            if (read != peSize)
-                return E_FAIL;
-        }
+        peBuf.resize(peSize);
+        peBufAddress = (ULONG64)&peBuf[0];
+        SIZE_T read = 0;
+        IfFailRet(process->ReadMemory(peAddress, peSize, &peBuf[0], &read));
+        if (read != peSize)
+            return E_FAIL;
     }
 
     return Interop::LoadSymbolsForPortablePDB(

--- a/src/metadata/modules.cpp
+++ b/src/metadata/modules.cpp
@@ -488,7 +488,7 @@ static HRESULT LoadSymbols(IMetaDataImport *pMD, ICorDebugModule *pModule, VOID 
     ULONG64 peBufAddress = 0;
     if (isInMemory)
     {
-        ICorDebugProcess* process = 0;
+        ToRelease<ICorDebugProcess> process;
         IfFailRet(pModule->GetProcess(&process));
 
         if (peAddress != 0 && peSize != 0)


### PR DESCRIPTION
This is a modification of PR #108 that only deals with symbol loading when loading in-memory modules.

This might fix related issues
#34
#91 

It at least fixes my issue with Godot symbols not being loaded.