### PR TITLE
Escape source path in VSCode protocol output event

### DIFF
--- a/src/protocols/vscodeprotocol.cpp
+++ b/src/protocols/vscodeprotocol.cpp
@@ -316,7 +316,8 @@ namespace
         if (!source.IsNull())
         {
             // "source":{"name":"Program.cs","path":"/path/Program.cs"}
-            stream << ",\"source\":{\"name\":\"" << source.name << "\",\"path\":\"" << source.path << "\"}";
+            EscapedString<JSON_escape_rules> escaped_source_path(source.path);
+            stream << ",\"source\":{\"name\":\"" << source.name << "\",\"path\":\"" << escaped_source_path << "\"}";
         }
 
         stream <<  "}}";


### PR DESCRIPTION
Fixes #175

Tested on Windows through nvim-dap with a .Net Core Web API template project, test suite is also still passing on Windows.
