### PR TITLE
handle unix file paths on Windows for setting breakpoints with dap

### DIFF
--- a/src/protocols/vscodeprotocol.cpp
+++ b/src/protocols/vscodeprotocol.cpp
@@ -575,8 +575,13 @@ static HRESULT HandleCommand(std::shared_ptr<IDebugger> &sharedDebugger, std::st
         for (auto &b : arguments.at("breakpoints"))
             lineBreakpoints.emplace_back(std::string(), b.at("line"), b.value("condition", std::string()));
 
+        std::string source = arguments.at("source").at("path");
+#ifdef WIN32
+        std::replace(source.begin(), source.end(), '/', '\\');
+#endif
+
         std::vector<Breakpoint> breakpoints;
-        IfFailRet(sharedDebugger->SetLineBreakpoints(arguments.at("source").at("path"), lineBreakpoints, breakpoints));
+        IfFailRet(sharedDebugger->SetLineBreakpoints(source, lineBreakpoints, breakpoints));
 
         body["breakpoints"] = breakpoints;
 


### PR DESCRIPTION
My DAP client sends file paths with forward slash on Mingw64 environment. I am not sure if DAP specification requires Windows paths being used but a quick search seemed not so.

Deep in the callstack there was a cache variable with sources to indexes and that cache had keys with Windows paths so my breakpoints weren't being set.

Aside from that, I have three comments.
1) I invested too much time for my symbols not being loaded. I saw PortablePDB functions but I didn't really think 'Portable' here was the new PDB format that should be generated through project settings. What I thought was, my PDB files are not embedded, and seperate, such that they can be moved so they are portable. Of course that is flawed but I think mentioning how PDB files must be generated in readme does not hurt.
2) Assertion at `modules_sources:68` was failing but I didn't look further. It was working fine if disabled. Maybe you would be interested.
3) Interpreter protocol name `vscode` doesn't reflect its full capability and may make people think it only works for VSCode. Maybe use something like `dap`? I think lldb went through same thing with `lldb-vscode` to `lldb-dap`.