### PR TITLE
Add memoryReference field for variables in dap protocol

### DIFF
--- a/src/debugger/variables.cpp
+++ b/src/debugger/variables.cpp
@@ -138,6 +138,18 @@ static HRESULT FetchFieldsAndProperties(Evaluator *pEvaluator, ICorDebugValue *p
     return S_OK;
 }
 
+static HRESULT GetMemoryReference(ICorDebugValue* pInputValue, uint64_t& memoryReference) {
+    HRESULT Status;
+
+    ToRelease<ICorDebugReferenceValue> pReferenceValue;
+    if (FAILED(pInputValue->QueryInterface(IID_ICorDebugReferenceValue, (void**)&pReferenceValue)))
+        IfFailRet(pInputValue->GetAddress(&memoryReference));
+    else
+        IfFailRet(pReferenceValue->GetValue(&memoryReference));
+
+    return S_OK;
+}
+
 int Variables::GetNamedVariables(uint32_t variablesReference)
 {
     std::lock_guard<std::recursive_mutex> lock(m_referencesMutex);
@@ -219,6 +231,7 @@ HRESULT Variables::GetExceptionVariable(FrameId frameId, ICorDebugThread *pThrea
         HRESULT Status;
         IfFailRet(PrintValue(pExceptionValue, var.value));
         IfFailRet(TypePrinter::GetTypeOfValue(pExceptionValue, var.type));
+        IfFailRet(GetMemoryReference(pExceptionValue, var.memoryReference));
 
         return AddVariableReference(var, frameId, pExceptionValue, ValueIsVariable);
     }
@@ -259,6 +272,7 @@ HRESULT Variables::GetStackVariables(
         IfFailRet(getValue(&iCorValue, var.evalFlags));
         IfFailRet(TypePrinter::GetTypeOfValue(iCorValue, var.type));
         IfFailRet(PrintValue(iCorValue, var.value));
+        IfFailRet(GetMemoryReference(iCorValue, var.memoryReference));
 
         IfFailRet(AddVariableReference(var, frameId, iCorValue, ValueIsVariable));
         variables.push_back(var);
@@ -355,6 +369,7 @@ HRESULT Variables::GetChildren(
         if (var.name.find('(') == std::string::npos) // expression evaluator does not support typecasts
             var.evaluateName = ref.evaluateName + (isIndex ? "" : ".") + var.name;
         IfFailRet(FillValueAndType(it, var));
+        IfFailRet(GetMemoryReference(it.value, var.memoryReference));
         IfFailRet(AddVariableReference(var, ref.frameId, it.value, ValueIsVariable));
         variables.push_back(var);
     }
@@ -405,6 +420,7 @@ HRESULT Variables::Evaluate(
     variable.evaluateName = expression;
     IfFailRet(TypePrinter::GetTypeOfValue(pResultValue, variable.type));
     IfFailRet(PrintValue(pResultValue, variable.value));
+    IfFailRet(GetMemoryReference(pResultValue, variable.memoryReference));
 
     return AddVariableReference(variable, frameId, pResultValue, ValueIsVariable);
 }

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -414,13 +414,14 @@ struct Variable
     std::string type;
     VariablePresentationHint presentationHint;
     std::string evaluateName;
+    uint64_t memoryReference;
     uint32_t variablesReference;
     int namedVariables;
     int indexedVariables;
     int evalFlags;
     bool editable;
 
-    Variable(int flags = defaultEvalFlags) : variablesReference(0), namedVariables(0), indexedVariables(0), evalFlags(flags), editable(false) {}
+    Variable(int flags = defaultEvalFlags) : memoryReference(0), variablesReference(0), namedVariables(0), indexedVariables(0), evalFlags(flags), editable(false) {}
 };
 
 enum VariablesFilter

--- a/src/protocols/vscodeprotocol.cpp
+++ b/src/protocols/vscodeprotocol.cpp
@@ -108,11 +108,15 @@ void to_json(json &j, const Scope &s) {
 }
 
 void to_json(json &j, const Variable &v) {
+    char memoryReference[19] = "0x0000000000000000";
+    snprintf(memoryReference, 19, "0x%016llx", v.memoryReference);
+
     j = json{
         {"name",               v.name},
         {"value",              v.value},
         {"type",               v.type},
         {"evaluateName",       v.evaluateName},
+        {"memoryReference",    memoryReference},
         {"variablesReference", v.variablesReference}};
 
     if (v.variablesReference > 0)


### PR DESCRIPTION
This adds the `memoryReference` field for the DAP `variables` request.
Other requests returning the `memoryReference` field have not been implemented yet.

## Use Case
I am programming a visualization tool that recursively traverses variables. The `memoryReference` field is used to detect if a variable has already been queried and must not be queried again.

## TODO

- [ ] Only send `memoryReference` field if client announces `supportsMemoryReferences`
- [ ] Add/Update Tests
- [ ] Determine if this PR should also implement the `memoryReference` field for
    - [ ] `setVariable` request
    - [ ] `evaluate` request
    - [ ] `setExpression` request

These TODOs are currently not implemented because they are not required for my use case.

Please let me know whether the project is interested in adding this functionality, and if so, to what extent it should be implemented so it can be upstreamed.