### PR TITLE
feat: enable Nullable<T> inspection for complex types (Guid?, DateTime?, etc.)

### DIFF
--- a/src/debugger/evaluator.cpp
+++ b/src/debugger/evaluator.cpp
@@ -778,8 +778,22 @@ static HRESULT InternalWalkMembers(EvalHelpers *pEvalHelpers, ICorDebugValue *pI
     if (className == "decimal") // TODO: implement mechanism for walking over custom type fields
         return S_OK;
 
-    if (className.back() == '?') // System.Nullable<T>, don't provide class member list.
+    if (className.back() == '?') // System.Nullable<T>
+    {
+        ToRelease<ICorDebugValue> pValueValue;
+        ToRelease<ICorDebugValue> pHasValueValue;
+        IfFailRet(GetNullableValue(pInputValue, &pValueValue, &pHasValueValue));
+
+        BYTE hasValueByte = 0;
+        ToRelease<ICorDebugGenericValue> pGenericValue;
+        IfFailRet(pHasValueValue->QueryInterface(IID_ICorDebugGenericValue, (LPVOID*)&pGenericValue));
+        IfFailRet(pGenericValue->GetValue((LPVOID)&hasValueByte));
+
+        if (hasValueByte != 0)
+            return InternalWalkMembers(pEvalHelpers, pValueValue, pThread, frameLevel, nullptr, provideSetterData, cb);
+
         return S_OK;
+    }
 
     CorElementType corElemType;
     IfFailRet(pType->GetType(&corElemType));


### PR DESCRIPTION
My attempt at fixing #213. Keep in mind that I usually never code in c++. 
In the case where my implementation has bugs or unhandled cases, feel free to tag me and describe what is missing. I'm happy to test and fix it.
I did test the code and it works for the cases described in #213. 

Fixes #213

### Test code

```cs
    Guid? x = Guid.NewGuid();
    Guid? y = null;
    Guid? z = new Guid();
    DateTime? dt1 = DateTime.Now;
    DateTime? dt2 = null;
    TimeSpan? ts1 = TimeSpan.FromSeconds(42);
    TimeSpan? ts2 = null;
    int? i1 = 42;
    int? i2 = null;
    bool? b1 = true;
    bool? b2 = null;
    double? d1 = 3.14;
    double? d2 = null;
    DayOfWeek? day1 = DayOfWeek.Monday;
    DayOfWeek? day2 = null;
    decimal? dec1 = 123.456m;
    decimal? dec2 = null;
```

### Background

I maintain https://github.com/GustavEikaas/easy-dotnet.nvim which relies on netcoredbg for debugging using nvim-dap and I use it daily. It is annoying to use repl window every time I see the type, but with variablesReference = 0.