### PR TITLE
feat: add breakpoint column support

### DIFF
--- a/src/debugger/breakpoints_line.cpp
+++ b/src/debugger/breakpoints_line.cpp
@@ -19,7 +19,9 @@ void LineBreakpoints::ManagedLineBreakpoint::ToBreakpoint(Breakpoint &breakpoint
     breakpoint.condition = this->condition;
     breakpoint.source = Source(fullname);
     breakpoint.line = this->linenum;
+    breakpoint.column = this->column;
     breakpoint.endLine = this->endLine;
+    breakpoint.endColumn = this->endColumn;
     breakpoint.hitCount = this->times;
 }
 
@@ -169,7 +171,7 @@ static HRESULT ResolveLineBreakpoint(Modules *pModules, ICorDebugModule *pModule
     else if (pModule) // Filter data from only one module during resolve, if need.
         IfFailRet(pModule->GetBaseAddress(&modAddress));
 
-    IfFailRet(pModules->ResolveBreakpoint(modAddress, bp_fullname, bp_fullname_index, bp.linenum, resolvedPoints));
+    IfFailRet(pModules->ResolveBreakpoint(modAddress, bp_fullname, bp_fullname_index, bp.linenum, bp.column, resolvedPoints));
     if (resolvedPoints.empty())
         return E_FAIL;
 
@@ -224,6 +226,8 @@ static HRESULT ActivateLineBreakpoint(LineBreakpoints::ManagedLineBreakpoint &bp
     // same for multiple breakpoint resolve for one module
     bp.linenum = resolvedPoints[0].startLine;
     bp.endLine = resolvedPoints[0].endLine;
+    bp.column = resolvedPoints[0].startColumn;
+    bp.endColumn = resolvedPoints[0].endColumn;
     bp.modAddress = modAddress;
 
     return S_OK;
@@ -245,6 +249,7 @@ HRESULT LineBreakpoints::ManagedCallbackLoadModule(ICorDebugModule *pModule, std
             bp.module = initialBreakpoint.breakpoint.module;
             bp.enabled = initialBreakpoint.enabled;
             bp.linenum = initialBreakpoint.breakpoint.line;
+            bp.column = initialBreakpoint.breakpoint.column;
             bp.endLine = initialBreakpoint.breakpoint.line;
             bp.condition = initialBreakpoint.breakpoint.condition;
             unsigned resolved_fullname_index = 0;
@@ -324,12 +329,13 @@ HRESULT LineBreakpoints::UpdateLineBreakpoint(bool haveProcess, int id, int line
             bp.module = initialBreakpoint.breakpoint.module;
             bp.enabled = initialBreakpoint.enabled;
             bp.linenum = initialBreakpoint.breakpoint.line;
+            bp.column = initialBreakpoint.breakpoint.column;
             bp.endLine = initialBreakpoint.breakpoint.line;
             bp.condition = initialBreakpoint.breakpoint.condition;
 
             unsigned resolved_fullname_index = 0;
             std::vector<ModulesSources::resolved_bp_t> resolvedPoints;
-            if (FAILED(m_sharedModules->ResolveBreakpoint(modAddress, initialBreakpoints.first, resolved_fullname_index, bp.linenum, resolvedPoints)) ||
+            if (FAILED(m_sharedModules->ResolveBreakpoint(modAddress, initialBreakpoints.first, resolved_fullname_index, bp.linenum, bp.column, resolvedPoints)) ||
                 FAILED(ActivateLineBreakpoint(bp, initialBreakpoints.first, m_justMyCode, resolvedPoints)))
             {
                 return S_OK;
@@ -434,6 +440,7 @@ HRESULT LineBreakpoints::SetLineBreakpoints(bool haveProcess, const std::string&
     for (const auto &sb : lineBreakpoints)
     {
         int line = sb.line;
+        int column = sb.column;
         Breakpoint breakpoint;
 
         auto b = breakpointsInSourceMap.find(line);
@@ -448,6 +455,7 @@ HRESULT LineBreakpoints::SetLineBreakpoints(bool haveProcess, const std::string&
             bp.id = initialBreakpoint.id;
             bp.module = initialBreakpoint.breakpoint.module;
             bp.linenum = line;
+            bp.column = column;
             bp.endLine = line;
             bp.condition = initialBreakpoint.breakpoint.condition;
             unsigned resolved_fullname_index = 0;
@@ -511,6 +519,7 @@ HRESULT LineBreakpoints::SetLineBreakpoints(bool haveProcess, const std::string&
                 bp.id = initialBreakpoint.id;
                 bp.module = initialBreakpoint.breakpoint.module;
                 bp.linenum = line;
+                bp.column = column;
                 bp.endLine = line;
                 bp.condition = initialBreakpoint.breakpoint.condition;
                 bp.ToBreakpoint(breakpoint, filename);
@@ -573,6 +582,7 @@ HRESULT LineBreakpoints::UpdateBreakpointsOnHotReload(ICorDebugModule *pModule, 
             bp.module = initialBreakpoint.breakpoint.module;
             bp.enabled = initialBreakpoint.enabled;
             bp.linenum = initialBreakpoint.breakpoint.line;
+            bp.column = initialBreakpoint.breakpoint.column;
             bp.endLine = initialBreakpoint.breakpoint.line;
             bp.condition = initialBreakpoint.breakpoint.condition;
             unsigned resolved_fullname_index = 0;

--- a/src/debugger/breakpoints_line.h
+++ b/src/debugger/breakpoints_line.h
@@ -62,7 +62,9 @@ public:
         std::string module;
         CORDB_ADDRESS modAddress;
         int linenum;
+        int column;
         int endLine;
+        int endColumn;
         bool enabled;
         ULONG32 times;
         std::string condition;
@@ -73,7 +75,7 @@ public:
         bool IsVerified() const { return !iCorFuncBreakpoints.empty(); }
 
         ManagedLineBreakpoint() :
-            id(0), modAddress(0), linenum(0), endLine(0), enabled(true), times(0)
+            id(0), modAddress(0), linenum(0), column(0), endLine(0), endColumn(0), enabled(true), times(0)
         {}
 
         ~ManagedLineBreakpoint()
@@ -107,7 +109,7 @@ private:
         unsigned resolved_fullname_index;
         int resolved_linenum; // if int is 0 - no resolved breakpoint available in m_lineResolvedBreakpoints
 
-        ManagedLineBreakpointMapping() : breakpoint("", 0, ""), id(0), enabled(true), resolved_fullname_index(0), resolved_linenum(0) {}
+        ManagedLineBreakpointMapping() : breakpoint("", 0, 0, ""), id(0), enabled(true), resolved_fullname_index(0), resolved_linenum(0) {}
         ~ManagedLineBreakpointMapping() = default;
     };
 

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -241,7 +241,9 @@ struct Breakpoint
     std::string message;
     Source source;
     int line;
+    int column;
     int endLine;
+    int endColumn;
 
     uint32_t hitCount; // exposed for MI protocol
     std::string condition;
@@ -249,7 +251,7 @@ struct Breakpoint
     std::string funcname;
     std::string params;
 
-    Breakpoint() : id(0), verified(false), line(0), endLine(0), hitCount(0) {}
+    Breakpoint() : id(0), verified(false), line(0), column(0), endLine(0), endColumn(0), hitCount(0) {}
 };
 
 enum SymbolStatus
@@ -434,13 +436,16 @@ struct LineBreakpoint
 {
     std::string module;
     int line;
+    int column;
     std::string condition;
 
     LineBreakpoint(const std::string &module,
                    int linenum,
+                   int col = 0,
                    const std::string &cond = std::string()) :
         module(module),
         line(linenum),
+        column(col),
         condition(cond)
     {}
 };

--- a/src/managed/SymbolReader.cs
+++ b/src/managed/SymbolReader.cs
@@ -695,13 +695,17 @@ namespace NetCoreDbg
         {
             public int startLine;
             public int endLine;
+            public int startColumn;
+            public int endColumn;
             public int ilOffset;
             public int methodToken;
 
-            public resolved_bp_t(int startLine_, int endLine_, int ilOffset_, int methodToken_)
+            public resolved_bp_t(int startLine_, int endLine_, int startColumn_, int endColumn_, int ilOffset_, int methodToken_)
             {
                 startLine = startLine_;
                 endLine = endLine_;
+                startColumn = startColumn_;
+                endColumn = endColumn_;
                 ilOffset = ilOffset_;
                 methodToken = methodToken_;
             }
@@ -722,7 +726,7 @@ namespace NetCoreDbg
         /// <param name="Count">entry's count in data</param>
         /// <param name="data">pointer to memory with result</param>
         /// <returns>"Ok" if information is available</returns>
-        internal static RetCode ResolveBreakPoints(IntPtr symbolReaderHandles, int tokenNum, IntPtr Tokens, int sourceLine, int nestedToken,
+        internal static RetCode ResolveBreakPoints(IntPtr symbolReaderHandles, int tokenNum, IntPtr Tokens, int sourceLine, int sourceColumn, int nestedToken,
                                                    out int Count, [MarshalAs(UnmanagedType.LPWStr)] string sourcePath, out IntPtr data)
         {
             Debug.Assert(symbolReaderHandles != IntPtr.Zero);
@@ -746,7 +750,7 @@ namespace NetCoreDbg
                 // We need check if nestedToken's method code closer to sourceLine than code from methodToken's method.
                 // If sourceLine closer to nestedToken's method code - setup breakpoint in nestedToken's method.
 
-                SequencePoint SequencePointForSourceLine(Position reqPos, ref MetadataReader reader, int methodToken)
+                SequencePoint SequencePointForSourceLine(Position reqPos, ref MetadataReader reader, int methodToken, bool filterByColumn = false)
                 {
                     // Note, SequencePoints ordered by IL offsets, not by line numbers.
                     // For example, infinite loop `while(true)` will have IL offset after cycle body's code.
@@ -755,6 +759,12 @@ namespace NetCoreDbg
                     foreach (SequencePoint p in GetSequencePointCollection(methodToken, reader))
                     {
                         if (p.StartLine == 0 || p.StartLine == SequencePoint.HiddenLine || p.EndLine < sourceLine)
+                            continue;
+
+                        // Skip sequence points that start strictly after our target column.
+                        // Use > (not >=) so a cursor placed exactly at a statement's start column is kept.
+                        // Only applied for the outer method — nested token calls use original line-only logic.
+                        if (filterByColumn && sourceColumn > 0 && p.StartLine == sourceLine && p.StartColumn > sourceColumn)
                             continue;
 
                         // Note, in case of constructors, we must care about source too, since we may have situation when field/property have same line in another source.
@@ -777,8 +787,16 @@ namespace NetCoreDbg
                         }
                         else
                         {
-                            if ((reqPos == Position.First && p.EndColumn < nearestSP.EndColumn) ||
-                                (reqPos == Position.Last && p.EndColumn > nearestSP.EndColumn))
+                            // For column-aware outer-method selection: prefer the sequence point whose
+                            // StartColumn is closest to (largest, not exceeding) the target column.
+                            // For nested token calls and plain line breakpoints: keep original EndColumn logic.
+                            if (filterByColumn && sourceColumn > 0 && p.StartLine == nearestSP.StartLine)
+                            {
+                                if (p.StartColumn > nearestSP.StartColumn)
+                                    nearestSP = p;
+                            }
+                            else if ((reqPos == Position.First && p.EndColumn < nearestSP.EndColumn) ||
+                                     (reqPos == Position.Last && p.EndColumn > nearestSP.EndColumn))
                                 nearestSP = p;
                         }
                     }
@@ -794,7 +812,7 @@ namespace NetCoreDbg
                     MetadataReader reader = ((OpenedReader)gch.Target).Reader;
 
                     int methodToken = Marshal.ReadInt32(Tokens, i * elementSize);
-                    SequencePoint current_p = SequencePointForSourceLine(Position.First, ref reader, methodToken);
+                    SequencePoint current_p = SequencePointForSourceLine(Position.First, ref reader, methodToken, filterByColumn: true);
                     // Note, we don't check that current_p was found or not, since we know for sure, that sourceLine could be resolved in method.
                     // Same idea for nested_p below, if we have nestedToken - it will be resolved for sure.
 
@@ -812,8 +830,17 @@ namespace NetCoreDbg
                         if ((nested_start_p.StartLine > current_p.StartLine || (nested_start_p.StartLine == current_p.StartLine && nested_start_p.StartColumn > current_p.StartColumn)) &&
                             (nested_end_p.EndLine < current_p.EndLine || (nested_end_p.EndLine == current_p.EndLine && nested_end_p.EndColumn < current_p.EndColumn ))
                         ) {
-                            list.Add(new resolved_bp_t(current_p.StartLine, current_p.EndLine, current_p.Offset, methodToken));
-                            break;
+                            // Nested is fully within current_p's range.
+                            // If column info places the cursor inside the nested body, fall through to
+                            // condition 2 so the breakpoint lands in the lambda, not the outer call.
+                            bool cursorInsideNested = sourceColumn > 0
+                                && sourceColumn >= nested_start_p.StartColumn
+                                && sourceColumn <= nested_end_p.EndColumn;
+                            if (!cursorInsideNested)
+                            {
+                                list.Add(new resolved_bp_t(current_p.StartLine, current_p.EndLine, current_p.StartColumn, current_p.EndColumn, current_p.Offset, methodToken));
+                                break;
+                            }
                         }
 
                         // Note, sequence points can't partially overlap each other, since same lemmas can't belong to 2 different sequence points for sure.
@@ -821,7 +848,7 @@ namespace NetCoreDbg
                         // current method sequence point and first nested method sequence point.
                         if (current_p.EndLine > nested_start_p.EndLine || (current_p.EndLine == nested_start_p.EndLine && current_p.EndColumn > nested_start_p.EndColumn))
                         {
-                            list.Add(new resolved_bp_t(nested_start_p.StartLine, nested_start_p.EndLine, nested_start_p.Offset, nestedToken));
+                            list.Add(new resolved_bp_t(nested_start_p.StartLine, nested_start_p.EndLine, nested_start_p.StartColumn, nested_start_p.EndColumn, nested_start_p.Offset, nestedToken));
                             // (tokenNum > 1) can have only lines, that added to multiple constructors, in this case - we will have same for all Tokens,
                             // we need unique tokens only for breakpoints, prevent adding nestedToken multiple times.
                             break;
@@ -829,7 +856,7 @@ namespace NetCoreDbg
                     }
                     nestedToken = 0; // Don't check nested block next cycle (will have same results).
 
-                    list.Add(new resolved_bp_t(current_p.StartLine, current_p.EndLine, current_p.Offset, methodToken));
+                    list.Add(new resolved_bp_t(current_p.StartLine, current_p.EndLine, current_p.StartColumn, current_p.EndColumn, current_p.Offset, methodToken));
                 }
 
                 if (list.Count == 0)

--- a/src/managed/interop.cpp
+++ b/src/managed/interop.cpp
@@ -65,7 +65,7 @@ typedef  RetCode (*GetSequencePointsDelegate)(PVOID, mdMethodDef, PVOID*, int32_
 typedef  RetCode (*GetNextUserCodeILOffsetDelegate)(PVOID, mdMethodDef, uint32_t, uint32_t*, int32_t*);
 typedef  RetCode (*GetStepRangesFromIPDelegate)(PVOID, int32_t, mdMethodDef, uint32_t*, uint32_t*);
 typedef  RetCode (*GetModuleMethodsRangesDelegate)(PVOID, uint32_t, PVOID, uint32_t, PVOID, PVOID*);
-typedef  RetCode (*ResolveBreakPointsDelegate)(PVOID[], int32_t, PVOID, int32_t, int32_t, int32_t*, const WCHAR*, PVOID*);
+typedef  RetCode (*ResolveBreakPointsDelegate)(PVOID[], int32_t, PVOID, int32_t, int32_t, int32_t, int32_t*, const WCHAR*, PVOID*);
 typedef  RetCode (*GetAsyncMethodSteppingInfoDelegate)(PVOID, mdMethodDef, PVOID*, int32_t*, uint32_t*);
 typedef  RetCode (*GetSourceDelegate)(PVOID, const WCHAR*, int32_t*, PVOID*);
 typedef  PVOID (*LoadDeltaPdbDelegate)(const WCHAR*, PVOID*, int32_t*);
@@ -429,13 +429,13 @@ HRESULT GetModuleMethodsRanges(PVOID pSymbolReaderHandle, uint32_t constrTokensN
     return retCode == RetCode::OK ? S_OK : E_FAIL;
 }
 
-HRESULT ResolveBreakPoints(PVOID pSymbolReaderHandles[], int32_t tokenNum, PVOID Tokens, int32_t sourceLine, int32_t nestedToken, int32_t &Count, const std::string &sourcePath, PVOID *data)
+HRESULT ResolveBreakPoints(PVOID pSymbolReaderHandles[], int32_t tokenNum, PVOID Tokens, int32_t sourceLine, int32_t sourceColumn, int32_t nestedToken, int32_t &Count, const std::string &sourcePath, PVOID *data)
 {
     std::unique_lock<Utility::RWLock::Reader> read_lock(CLRrwlock.reader);
     if (!resolveBreakPointsDelegate || !pSymbolReaderHandles || !Tokens || !data)
         return E_FAIL;
 
-    RetCode retCode = resolveBreakPointsDelegate(pSymbolReaderHandles, tokenNum, Tokens, sourceLine, nestedToken, &Count, to_utf16(sourcePath).c_str(), data);
+    RetCode retCode = resolveBreakPointsDelegate(pSymbolReaderHandles, tokenNum, Tokens, sourceLine, sourceColumn, nestedToken, &Count, to_utf16(sourcePath).c_str(), data);
     return retCode == RetCode::OK ? S_OK : E_FAIL;
 }
 

--- a/src/managed/interop.h
+++ b/src/managed/interop.h
@@ -95,7 +95,7 @@ namespace Interop
     HRESULT GetHoistedLocalScopes(PVOID pSymbolReaderHandle, mdMethodDef methodToken, PVOID *data, int32_t &hoistedLocalScopesCount);
     HRESULT GetStepRangesFromIP(PVOID pSymbolReaderHandle, ULONG32 ip, mdMethodDef MethodToken, ULONG32 *ilStartOffset, ULONG32 *ilEndOffset);
     HRESULT GetModuleMethodsRanges(PVOID pSymbolReaderHandle, uint32_t constrTokensNum, PVOID constrTokens, uint32_t normalTokensNum, PVOID normalTokens, PVOID *data);
-    HRESULT ResolveBreakPoints(PVOID pSymbolReaderHandles[], int32_t tokenNum, PVOID Tokens, int32_t sourceLine, int32_t nestedToken, int32_t &Count, const std::string &sourcePath, PVOID *data);
+    HRESULT ResolveBreakPoints(PVOID pSymbolReaderHandles[], int32_t tokenNum, PVOID Tokens, int32_t sourceLine, int32_t sourceColumn, int32_t nestedToken, int32_t &Count, const std::string &sourcePath, PVOID *data);
     HRESULT GetAsyncMethodSteppingInfo(PVOID pSymbolReaderHandle, mdMethodDef methodToken, std::vector<AsyncAwaitInfoBlock> &AsyncAwaitInfo, ULONG32 *ilOffset);
     HRESULT GetSource(PVOID symbolReaderHandle, const std::string fileName, PVOID *data, int32_t *length);
     HRESULT LoadDeltaPdb(const std::string &pdbPath, VOID **ppSymbolReaderHandle, std::unordered_set<mdMethodDef> &methodTokens);

--- a/src/metadata/modules.cpp
+++ b/src/metadata/modules.cpp
@@ -740,7 +740,7 @@ HRESULT Modules::ForEachModule(std::function<HRESULT(ICorDebugModule *pModule)> 
 }
 
 HRESULT Modules::ResolveBreakpoint(/*in*/ CORDB_ADDRESS modAddress, /*in*/ std::string filename, /*out*/ unsigned &fullname_index,
-                                   /*in*/ int sourceLine, /*out*/ std::vector<ModulesSources::resolved_bp_t> &resolvedPoints)
+                                   /*in*/ int sourceLine, /*in*/ int sourceColumn, /*out*/ std::vector<ModulesSources::resolved_bp_t> &resolvedPoints)
 {
 #ifdef WIN32
     HRESULT Status;
@@ -749,7 +749,7 @@ HRESULT Modules::ResolveBreakpoint(/*in*/ CORDB_ADDRESS modAddress, /*in*/ std::
 
     // Note, in all code we use m_modulesInfoMutex > m_sourcesInfoMutex lock sequence.
     std::lock_guard<std::mutex> lockModulesInfo(m_modulesInfoMutex);
-    return m_modulesSources.ResolveBreakpoint(this, modAddress, filename, fullname_index, sourceLine, resolvedPoints);
+    return m_modulesSources.ResolveBreakpoint(this, modAddress, filename, fullname_index, sourceLine, sourceColumn, resolvedPoints);
 }
 
 HRESULT Modules::ApplyPdbDeltaAndLineUpdates(ICorDebugModule *pModule, bool needJMC, const std::string &deltaPDB,

--- a/src/metadata/modules.h
+++ b/src/metadata/modules.h
@@ -71,6 +71,7 @@ public:
         /*in*/ std::string filename,
         /*out*/ unsigned &fullname_index,
         /*in*/ int sourceLine,
+        /*in*/ int sourceColumn,
         /*out*/ std::vector<ModulesSources::resolved_bp_t> &resolvedPoints);
 
     HRESULT GetSourceFullPathByIndex(unsigned index, std::string &fullPath);

--- a/src/metadata/modules_sources.cpp
+++ b/src/metadata/modules_sources.cpp
@@ -707,7 +707,7 @@ static void LineUpdatesBackwardCorrection(unsigned fullPathIndex, mdMethodDef me
 }
 
 HRESULT ModulesSources::ResolveBreakpoint(/*in*/ Modules *pModules, /*in*/ CORDB_ADDRESS modAddress, /*in*/ std::string filename, /*out*/ unsigned &fullname_index,
-                                          /*in*/ int sourceLine, /*out*/ std::vector<resolved_bp_t> &resolvedPoints)
+                                          /*in*/ int sourceLine, /*in*/ int sourceColumn, /*out*/ std::vector<resolved_bp_t> &resolvedPoints)
 {
     std::lock_guard<std::mutex> lockSourcesInfo(m_sourcesInfoMutex);
 
@@ -739,6 +739,8 @@ HRESULT ModulesSources::ResolveBreakpoint(/*in*/ Modules *pModules, /*in*/ CORDB
     {
         int32_t startLine;
         int32_t endLine;
+        int32_t startColumn;
+        int32_t endColumn;
         uint32_t ilOffset;
         uint32_t methodToken;
     };
@@ -805,7 +807,7 @@ HRESULT ModulesSources::ResolveBreakpoint(/*in*/ Modules *pModules, /*in*/ CORDB
         std::string fullName = m_sourceIndexToInitialFullPath[findIndex->second];
 #endif
         if (FAILED(Interop::ResolveBreakPoints(symbolReaderHandles.data(), (int32_t)Tokens.size(), Tokens.data(),
-                                               correctedStartLine, closestNestedToken, Count, fullName, &data))
+                                               correctedStartLine, sourceColumn, closestNestedToken, Count, fullName, &data))
             || data == nullptr)
         {
             continue;
@@ -819,7 +821,9 @@ HRESULT ModulesSources::ResolveBreakpoint(/*in*/ Modules *pModules, /*in*/ CORDB
             // In case Hot Reload we may have line updates that we must take into account.
             LineUpdatesForwardCorrection(findIndex->second, inputData.get()[i].methodToken, pmdInfo->m_methodBlockUpdates, inputData.get()[i]);
 
-            resolvedPoints.emplace_back(resolved_bp_t(inputData.get()[i].startLine, inputData.get()[i].endLine, inputData.get()[i].ilOffset,
+            resolvedPoints.emplace_back(resolved_bp_t(inputData.get()[i].startLine, inputData.get()[i].endLine,
+                                                      inputData.get()[i].startColumn, inputData.get()[i].endColumn,
+                                                      inputData.get()[i].ilOffset,
                                                       inputData.get()[i].methodToken, pmdInfo->m_iCorModule.GetPtr()));
         }
     }

--- a/src/metadata/modules_sources.h
+++ b/src/metadata/modules_sources.h
@@ -136,13 +136,17 @@ public:
     {
         int32_t startLine;
         int32_t endLine;
+        int32_t startColumn;
+        int32_t endColumn;
         uint32_t ilOffset;
         uint32_t methodToken;
         ToRelease<ICorDebugModule> iCorModule;
 
-        resolved_bp_t(int32_t startLine_, int32_t endLine_, uint32_t ilOffset_, uint32_t methodToken_, ICorDebugModule *pModule) :
+        resolved_bp_t(int32_t startLine_, int32_t endLine_, int32_t startColumn_, int32_t endColumn_, uint32_t ilOffset_, uint32_t methodToken_, ICorDebugModule *pModule) :
             startLine(startLine_),
             endLine(endLine_),
+            startColumn(startColumn_),
+            endColumn(endColumn_),
             ilOffset(ilOffset_),
             methodToken(methodToken_),
             iCorModule(pModule)
@@ -155,6 +159,7 @@ public:
         /*in*/ std::string filename,
         /*out*/ unsigned &fullname_index,
         /*in*/ int sourceLine,
+        /*in*/ int sourceColumn,
         /*out*/ std::vector<resolved_bp_t> &resolvedPoints);
 
     HRESULT FillSourcesCodeLinesForModule(ICorDebugModule *pModule, IMetaDataImport *pMDImport, PVOID pSymbolReaderHandle);

--- a/src/protocols/protocol_utils.cpp
+++ b/src/protocols/protocol_utils.cpp
@@ -61,7 +61,7 @@ HRESULT BreakpointsHandle::SetLineBreakpoint(std::shared_ptr<IDebugger> &sharedD
     for (auto it : breakpointsInSource)
         lineBreakpoints.push_back(it.second);
 
-    lineBreakpoints.emplace_back(module, linenum, condition);
+    lineBreakpoints.emplace_back(module, linenum, 0, condition);
 
     std::vector<Breakpoint> breakpoints;
     IfFailRet(sharedDebugger->SetLineBreakpoints(filename, lineBreakpoints, breakpoints));

--- a/src/protocols/vscodeprotocol.cpp
+++ b/src/protocols/vscodeprotocol.cpp
@@ -68,8 +68,12 @@ void to_json(json &j, const Breakpoint &b) {
         {"verified", b.verified}};
     if (!b.message.empty())
         j["message"] = b.message;
+    if (b.column > 0)
+        j["column"] = b.column;
     if (b.verified) {
         j["endLine"] = b.endLine;
+        if (b.endColumn > 0)
+            j["endColumn"] = b.endColumn;
         if (!b.source.IsNull())
             j["source"] = b.source;
     }
@@ -573,7 +577,7 @@ static HRESULT HandleCommand(std::shared_ptr<IDebugger> &sharedDebugger, std::st
 
         std::vector<LineBreakpoint> lineBreakpoints;
         for (auto &b : arguments.at("breakpoints"))
-            lineBreakpoints.emplace_back(std::string(), b.at("line"), b.value("condition", std::string()));
+            lineBreakpoints.emplace_back(std::string(), b.at("line"), b.value("column", 0), b.value("condition", std::string()));
 
         std::vector<Breakpoint> breakpoints;
         IfFailRet(sharedDebugger->SetLineBreakpoints(arguments.at("source").at("path"), lineBreakpoints, breakpoints));

--- a/test-suite/VSCodeTestSrcBreakpointResolve/Program.cs
+++ b/test-suite/VSCodeTestSrcBreakpointResolve/Program.cs
@@ -97,7 +97,7 @@ namespace NetcoreDbgTest.Script
             return ((LineBreakpoint)bp).NumLine;
         }
 
-        public void AddBreakpoint(string caller_trace, string bpName, string bpPath = null, string Condition = null, int? Column = null)
+        public void AddBreakpoint(string caller_trace, string bpName, string bpPath = null, string Condition = null, int? Column = 0)
         {
             Breakpoint bp = ControlInfo.Breakpoints[bpName];
             Assert.Equal(BreakpointType.Line, bp.Type, @"__FILE__:__LINE__"+"\n"+caller_trace);
@@ -236,13 +236,11 @@ namespace NetcoreDbgTest.Script
 
             StackTraceResponse stackTraceResponse =
                 JsonConvert.DeserializeObject<StackTraceResponse>(ret.ResponseStr);
+            var stackFrame = stackTraceResponse.body.stackFrames[0];
 
-            if (stackTraceResponse.body.stackFrames[0].line == bp_line
-                && stackTraceResponse.body.stackFrames[0].source.name == bp_fileName
-                && stackTraceResponse.body.stackFrames[0].column == expectedColumn)
-                return;
-
-            throw new ResultNotSuccessException(@"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(bp_line, stackFrame.line, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(bp_fileName, stackFrame.source.name, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(expectedColumn, stackFrame.column, @"__FILE__:__LINE__"+"\n"+caller_trace);
         }
 
         public void WasBreakpointHitAtStartColumn(string caller_trace, string bpName, int expectedColumn)
@@ -268,13 +266,11 @@ namespace NetcoreDbgTest.Script
             Breakpoint breakpoint = ControlInfo.Breakpoints[bpName];
             var lbp = (LineBreakpoint)breakpoint;
             StackTraceResponse stackTraceResponse = JsonConvert.DeserializeObject<StackTraceResponse>(ret.ResponseStr);
+            var stackFrame = stackTraceResponse.body.stackFrames[0];
 
-            if (stackTraceResponse.body.stackFrames[0].line == lbp.NumLine
-                && stackTraceResponse.body.stackFrames[0].source.name == lbp.FileName
-                && stackTraceResponse.body.stackFrames[0].column == expectedColumn)
-                return;
-
-            throw new ResultNotSuccessException(@"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(lbp.NumLine, stackFrame.line, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(lbp.FileName, stackFrame.source.name, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(expectedColumn, stackFrame.column, @"__FILE__:__LINE__"+"\n"+caller_trace);
         }
 
         public void WasBreakpointHitAtColumn(string caller_trace, string bpName, int expectedColumn, int expectedEndColumn)
@@ -303,14 +299,12 @@ namespace NetcoreDbgTest.Script
 
             StackTraceResponse stackTraceResponse =
                 JsonConvert.DeserializeObject<StackTraceResponse>(ret.ResponseStr);
+            var stackFrame = stackTraceResponse.body.stackFrames[0];
 
-            if (stackTraceResponse.body.stackFrames[0].line == lbp.NumLine
-                && stackTraceResponse.body.stackFrames[0].source.name == lbp.FileName
-                && stackTraceResponse.body.stackFrames[0].column == expectedColumn
-                && stackTraceResponse.body.stackFrames[0].endColumn == expectedEndColumn)
-                return;
-
-            throw new ResultNotSuccessException(@"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(lbp.NumLine, stackFrame.line, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(lbp.FileName, stackFrame.source.name, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(expectedColumn, stackFrame.column, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            Assert.Equal(expectedEndColumn, stackFrame.endColumn, @"__FILE__:__LINE__"+"\n"+caller_trace);
         }
 
         public void AddManualBreakpoint(string caller_trace, string bp_fileName, int bp_line, int? Column = null)
@@ -715,12 +709,12 @@ Label.Breakpoint("bp20_2");            numbers.ForEach(delegate(string number) {
                 Context.AddManualBreakpoint(@"__FILE__:__LINE__", "Program.cs", endLine - 1, Column: 5);
 
                 // Multiple breakpoints on the same line coalesce to a single BP at the start of the line, max 1 breakpoint-per line rule
-                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_A", Column: 0);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_A");
                 Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_A", Column: 17);
                 Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_A", Column: 23);
 
                 Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_B", Column: 17);
-                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_B", Column: 0);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_B");
                 Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_B", Column: 23);
 
                 Context.SetBreakpoints(@"__FILE__:__LINE__");

--- a/test-suite/VSCodeTestSrcBreakpointResolve/Program.cs
+++ b/test-suite/VSCodeTestSrcBreakpointResolve/Program.cs
@@ -91,8 +91,13 @@ namespace NetcoreDbgTest.Script
             disconnectRequest.arguments.restart = false;
             Assert.True(VSCodeDebugger.Request(disconnectRequest).Success, @"__FILE__:__LINE__"+"\n"+caller_trace);
         }
+        public int GetBreakpointLine(string bpName)
+        {
+            Breakpoint bp = ControlInfo.Breakpoints[bpName];
+            return ((LineBreakpoint)bp).NumLine;
+        }
 
-        public void AddBreakpoint(string caller_trace, string bpName, string bpPath = null, string Condition = null)
+        public void AddBreakpoint(string caller_trace, string bpName, string bpPath = null, string Condition = null, int? Column = null)
         {
             Breakpoint bp = ControlInfo.Breakpoints[bpName];
             Assert.Equal(BreakpointType.Line, bp.Type, @"__FILE__:__LINE__"+"\n"+caller_trace);
@@ -104,7 +109,7 @@ namespace NetcoreDbgTest.Script
                 listBp = new List<SourceBreakpoint>();
                 SrcBreakpoints[sourceFile] = listBp;
             }
-            listBp.Add(new SourceBreakpoint(lbp.NumLine, Condition));
+            listBp.Add(new SourceBreakpoint(lbp.NumLine, Condition) { column = Column });
 
             List<int?> listBpId;
             if (!SrcBreakpointIds.TryGetValue(sourceFile, out listBpId)) {
@@ -209,15 +214,113 @@ namespace NetcoreDbgTest.Script
 
             throw new ResultNotSuccessException(@"__FILE__:__LINE__"+"\n"+caller_trace);
         }
+        public void WasManualBreakpointHitAtColumn(string caller_trace, string bp_fileName, int bp_line, int expectedColumn)
+        {
+            Func<string, bool> filter = (resJSON) => {
+                if (VSCodeDebugger.isResponseContainProperty(resJSON, "event", "stopped")
+                    && VSCodeDebugger.isResponseContainProperty(resJSON, "reason", "breakpoint")) {
+                    threadId = Convert.ToInt32(VSCodeDebugger.GetResponsePropertyValue(resJSON, "threadId"));
+                    return true;
+                }
+                return false;
+            };
 
-        public void AddManualBreakpoint(string caller_trace, string bp_fileName, int bp_line)
+            Assert.True(VSCodeDebugger.IsEventReceived(filter), @"__FILE__:__LINE__"+"\n"+caller_trace);
+
+            StackTraceRequest stackTraceRequest = new StackTraceRequest();
+            stackTraceRequest.arguments.threadId = threadId;
+            stackTraceRequest.arguments.startFrame = 0;
+            stackTraceRequest.arguments.levels = 20;
+            var ret = VSCodeDebugger.Request(stackTraceRequest);
+            Assert.True(ret.Success, @"__FILE__:__LINE__"+"\n"+caller_trace);
+
+            StackTraceResponse stackTraceResponse =
+                JsonConvert.DeserializeObject<StackTraceResponse>(ret.ResponseStr);
+
+            if (stackTraceResponse.body.stackFrames[0].line == bp_line
+                && stackTraceResponse.body.stackFrames[0].source.name == bp_fileName
+                && stackTraceResponse.body.stackFrames[0].column == expectedColumn)
+                return;
+
+            throw new ResultNotSuccessException(@"__FILE__:__LINE__"+"\n"+caller_trace);
+        }
+
+        public void WasBreakpointHitAtStartColumn(string caller_trace, string bpName, int expectedColumn)
+        {
+            Func<string, bool> filter = (resJSON) => {
+                if (VSCodeDebugger.isResponseContainProperty(resJSON, "event", "stopped")
+                    && VSCodeDebugger.isResponseContainProperty(resJSON, "reason", "breakpoint")) {
+                    threadId = Convert.ToInt32(VSCodeDebugger.GetResponsePropertyValue(resJSON, "threadId"));
+                    return true;
+                }
+                return false;
+            };
+
+            Assert.True(VSCodeDebugger.IsEventReceived(filter), @"__FILE__:__LINE__"+"\n"+caller_trace);
+
+            StackTraceRequest stackTraceRequest = new StackTraceRequest();
+            stackTraceRequest.arguments.threadId = threadId;
+            stackTraceRequest.arguments.startFrame = 0;
+            stackTraceRequest.arguments.levels = 20;
+            var ret = VSCodeDebugger.Request(stackTraceRequest);
+            Assert.True(ret.Success, @"__FILE__:__LINE__"+"\n"+caller_trace);
+
+            Breakpoint breakpoint = ControlInfo.Breakpoints[bpName];
+            var lbp = (LineBreakpoint)breakpoint;
+            StackTraceResponse stackTraceResponse = JsonConvert.DeserializeObject<StackTraceResponse>(ret.ResponseStr);
+
+            if (stackTraceResponse.body.stackFrames[0].line == lbp.NumLine
+                && stackTraceResponse.body.stackFrames[0].source.name == lbp.FileName
+                && stackTraceResponse.body.stackFrames[0].column == expectedColumn)
+                return;
+
+            throw new ResultNotSuccessException(@"__FILE__:__LINE__"+"\n"+caller_trace);
+        }
+
+        public void WasBreakpointHitAtColumn(string caller_trace, string bpName, int expectedColumn, int expectedEndColumn)
+        {
+            Func<string, bool> filter = (resJSON) => {
+                if (VSCodeDebugger.isResponseContainProperty(resJSON, "event", "stopped")
+                    && VSCodeDebugger.isResponseContainProperty(resJSON, "reason", "breakpoint")) {
+                    threadId = Convert.ToInt32(VSCodeDebugger.GetResponsePropertyValue(resJSON, "threadId"));
+                    return true;
+                }
+                return false;
+            };
+
+            Assert.True(VSCodeDebugger.IsEventReceived(filter), @"__FILE__:__LINE__"+"\n"+caller_trace);
+
+            StackTraceRequest stackTraceRequest = new StackTraceRequest();
+            stackTraceRequest.arguments.threadId = threadId;
+            stackTraceRequest.arguments.startFrame = 0;
+            stackTraceRequest.arguments.levels = 20;
+            var ret = VSCodeDebugger.Request(stackTraceRequest);
+            Assert.True(ret.Success, @"__FILE__:__LINE__"+"\n"+caller_trace);
+
+            Breakpoint breakpoint = ControlInfo.Breakpoints[bpName];
+            Assert.Equal(BreakpointType.Line, breakpoint.Type, @"__FILE__:__LINE__"+"\n"+caller_trace);
+            var lbp = (LineBreakpoint)breakpoint;
+
+            StackTraceResponse stackTraceResponse =
+                JsonConvert.DeserializeObject<StackTraceResponse>(ret.ResponseStr);
+
+            if (stackTraceResponse.body.stackFrames[0].line == lbp.NumLine
+                && stackTraceResponse.body.stackFrames[0].source.name == lbp.FileName
+                && stackTraceResponse.body.stackFrames[0].column == expectedColumn
+                && stackTraceResponse.body.stackFrames[0].endColumn == expectedEndColumn)
+                return;
+
+            throw new ResultNotSuccessException(@"__FILE__:__LINE__"+"\n"+caller_trace);
+        }
+
+        public void AddManualBreakpoint(string caller_trace, string bp_fileName, int bp_line, int? Column = null)
         {
             List<SourceBreakpoint> listBp;
             if (!SrcBreakpoints.TryGetValue(bp_fileName, out listBp)) {
                 listBp = new List<SourceBreakpoint>();
                 SrcBreakpoints[bp_fileName] = listBp;
             }
-            listBp.Add(new SourceBreakpoint(bp_line, null));
+            listBp.Add(new SourceBreakpoint(bp_line, null) { column = Column });
 
             List<int?> listBpId;
             if (!SrcBreakpointIds.TryGetValue(bp_fileName, out listBpId)) {
@@ -576,15 +679,15 @@ Label.Breakpoint("bp20_2");            numbers.ForEach(delegate(string number) {
                 Context Context = (Context)context;
                 Context.WasBreakpointHit(@"__FILE__:__LINE__", "bp23");
 
-                Context.AddManualBreakpoint(@"__FILE__:__LINE__", "Program.cs", 287); // line number with "int test_field = 5;" code
-                Context.AddManualBreakpoint(@"__FILE__:__LINE__", "Program.cs", 291); // line number with "int i = 5;" code
+                Context.AddManualBreakpoint(@"__FILE__:__LINE__", "Program.cs", 390); // line number with "int test_field = 5;" code
+                Context.AddManualBreakpoint(@"__FILE__:__LINE__", "Program.cs", 394); // line number with "int i = 5;" code
                 Context.SetBreakpoints(@"__FILE__:__LINE__");
                 Context.Continue(@"__FILE__:__LINE__");
-                Context.WasManualBreakpointHit(@"__FILE__:__LINE__", "Program.cs", 287); // line number with "int test_field = 5;" code
+                Context.WasManualBreakpointHit(@"__FILE__:__LINE__", "Program.cs", 390); // line number with "int test_field = 5;" code
                 Context.Continue(@"__FILE__:__LINE__");
-                Context.WasManualBreakpointHit(@"__FILE__:__LINE__", "Program.cs", 291); // line number with "int i = 5;" code
+                Context.WasManualBreakpointHit(@"__FILE__:__LINE__", "Program.cs", 394); // line number with "int i = 5;" code
                 Context.Continue(@"__FILE__:__LINE__");
-                Context.WasManualBreakpointHit(@"__FILE__:__LINE__", "Program.cs", 287); // line number with "int test_field = 5;" code
+                Context.WasManualBreakpointHit(@"__FILE__:__LINE__", "Program.cs", 390); // line number with "int test_field = 5;" code
                 Context.Continue(@"__FILE__:__LINE__");
             });
 
@@ -595,11 +698,70 @@ Label.Breakpoint("bp20_2");            numbers.ForEach(delegate(string number) {
                 break;                                                              Label.Breakpoint("bp25");
             }
 
-            Label.Checkpoint("bp_test_not_ordered_line_num", "finish", (Object context) => {
+            Label.Checkpoint("bp_test_not_ordered_line_num", "bp_test_column", (Object context) => {
                 Context Context = (Context)context;
                 Context.WasBreakpointHit(@"__FILE__:__LINE__", "bp24");
                 Context.Continue(@"__FILE__:__LINE__");
                 Context.WasBreakpointHit(@"__FILE__:__LINE__", "bp25");
+
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_col1", Column: 13);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_col2", Column: 28);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_col3", Column: 43);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_col4", Column: 35);
+
+                int endLine = Context.GetBreakpointLine("multi_end");
+
+                // Multiline statement: breakpoint set with a column on the non-first line snaps up to the start of the statement.
+                Context.AddManualBreakpoint(@"__FILE__:__LINE__", "Program.cs", endLine - 1, Column: 5);
+
+                // Multiple breakpoints on the same line coalesce to a single BP at the start of the line, max 1 breakpoint-per line rule
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_A", Column: 0);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_A", Column: 17);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_A", Column: 23);
+
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_B", Column: 17);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_B", Column: 0);
+                Context.AddBreakpoint(@"__FILE__:__LINE__", "bp_multi_order_B", Column: 23);
+
+                Context.SetBreakpoints(@"__FILE__:__LINE__");
+                Context.Continue(@"__FILE__:__LINE__");
+            });
+
+            int col_a1 = 0;int col_b1 = 5;int col_c1 = 9;                               Label.Breakpoint("bp_col1");
+            int col_a2 = 0;int col_b2 = 5;int col_c2 = 9;                               Label.Breakpoint("bp_col2");
+            int col_a3 = 0;int col_b3 = 5;int col_c3 = 9;                               Label.Breakpoint("bp_col3");
+            int col_a4 = 0;int col_b4 = 5;int col_c4 = 9;                               Label.Breakpoint("bp_col4");
+
+            int a =
+            1 + 25 +
+            12 + 5; int b = 5;                                                          Label.Breakpoint("multi_end");
+
+            int i1 = 0; i1++; i1--; i1 = 5;                                             Label.Breakpoint("bp_multi_order_A");
+            int i2 = 0; i2++; i2--; i2 = 5;                                             Label.Breakpoint("bp_multi_order_B");
+
+            Label.Checkpoint("bp_test_column", "finish", (Object context) => {
+                Context Context = (Context)context;
+                int endLine = Context.GetBreakpointLine("multi_end");
+
+                Context.WasBreakpointHitAtColumn(@"__FILE__:__LINE__", "bp_col1", 13, 28);
+                Context.Continue(@"__FILE__:__LINE__");
+                Context.WasBreakpointHitAtColumn(@"__FILE__:__LINE__", "bp_col2", 28, 43);
+                Context.Continue(@"__FILE__:__LINE__");
+                Context.WasBreakpointHitAtColumn(@"__FILE__:__LINE__", "bp_col3", 43, 58);
+                Context.Continue(@"__FILE__:__LINE__");
+                Context.WasBreakpointHitAtColumn(@"__FILE__:__LINE__", "bp_col4", 28, 43);
+                Context.Continue(@"__FILE__:__LINE__");
+
+                // Multiline snap-up: the BP was set on the 2nd line of a 3-line statement and resolves to 'int a =' one line above that
+                Context.WasManualBreakpointHitAtColumn(@"__FILE__:__LINE__", "Program.cs", endLine - 2, 13);
+                Context.Continue(@"__FILE__:__LINE__");
+
+                // Order A: col 0, 17, 23 all coalesce to one BP at start of line
+                Context.WasBreakpointHitAtStartColumn(@"__FILE__:__LINE__", "bp_multi_order_A", 13);
+                Context.Continue(@"__FILE__:__LINE__");
+
+                // Order B: col 17, 0, 23 — order doesn't matter, still one BP at start of line
+                Context.WasBreakpointHitAtStartColumn(@"__FILE__:__LINE__", "bp_multi_order_B", 13);
                 Context.Continue(@"__FILE__:__LINE__");
             });
 


### PR DESCRIPTION
My attempt at implementing what was discussed in #219 and resolves #83.                                                                                                                 
                                                                                                                                                                                          
As discussed with @viewizard, the approach is: use the column to pick the right IL offset while keeping the 1 breakpoint per line rule. Column 0 falls back to existing behavior.                                                                                                                                                                              

I had to make some heuristics changes in SymbolReader.cs, feel free to sanity check me. 
    
When a column is provided, sequence point selection for the outer method prefers the SP whose StartColumn is closest to (but not exceeding) the target column. A cursorInsideNested guard ensures that when the cursor is positioned inside a lambda's column range, the breakpoint lands in the lambda rather than the outer call site.

column and endColumn are now returned in the DAP setBreakpoints response.                                                                                                               
 
The test case from #83 now works. Tested locally in neovim with various changes and seems to work as expected

Keep in mind I usually never code in C++. If there are edge cases I've missed feel free to tag me and I'll test and fix.

Fixes #83  
